### PR TITLE
Update to Sertanista Dynasty Names and Naming Chance to Children

### DIFF
--- a/actual game files/ate-ck3/common/culture/cultures/000_nordestino.txt
+++ b/actual game files/ate-ck3/common/culture/cultures/000_nordestino.txt
@@ -16,48 +16,43 @@
 		cadet_dynasty_names = {
 			"dynn_A_c_ced_ucena"
 			"dynn_Acerola"
-			"dynn_Alem_a_tld_o"
-			"dynn_Alves"
-			"dynn_Amante"
-			"dynn_Amea_c_ced_o"
+			"dynn_Amado"
+			"dynn_Andiroba"
 			"dynn_Andorinha"
 			"dynn_Ariranha"
-			"dynn_Arvoredo"
+			"dynn_Arvor_e_hat_do"
 			"dynn_Asa_Branca"
 			"dynn_Atividade"
 			"dynn_Bacalhau"
 			"dynn_Baga_c_ced_o"
-			"dynn_Baiano"
 			"dynn_Bal_a_tld_o"
 			"dynn_Baliza"
 			"dynn_Bananeira"
-			"dynn_Barbosa"
+			"dynn_Babosa"
 			"dynn_Barra_Nova"
 			"dynn_Barreiro"
-			"dynn_Batista"
 			"dynn_Beija-Flor"
 			"dynn_Bem-Te-Vi"
-			"dynn_Benevides"
-			"dynn_Bicheiro"
-			"dynn_Bimb_a_tld_o"
-			"dynn_Bizarria"
-			"dynn_Boa_Vista"
-			"dynn_Boca_Negra"
-			"dynn_Boiadeiro"
+			"dynn_Bicudo"
+			"dynn_Bigodinho"
+			"dynn_Vista-Boa"
+			"dynn_Bocanegra"
 			"dynn_Borboleta"
 			"dynn_Br_a_act_s"
 			"dynn_Branco"
 			"dynn_Bravo"
 			"dynn_Brilhante"
-			"dynn_Brito"
+			"dynn_Brita"
 			"dynn_Bronzeado"
+			"dynn_Carna_u_act_ba"
 			"dynn_C_o_hat_co"
+			"dynn_Coqueiros"
 			"dynn_Cabeleira"
 			"dynn_Cabo_Preto"
 			"dynn_Cacheado"
+			"dynn_Carcar_a_act_"
 			"dynn_Cachimbo"
 			"dynn_Caf_e_act_"
-			"dynn_Cafezal"
 			"dynn_Cai_c_ced_ara"
 			"dynn_Caipira"
 			"dynn_Caix_a_tld_o"
@@ -67,41 +62,34 @@
 			"dynn_Cambuci"
 			"dynn_Canabrava"
 			"dynn_Canavieira"
-			"dynn_Candango"
 			"dynn_Canhoto"
-			"dynn_Cansan_c_ced__a_tld_o"
-			"dynn_Capixaba"
+			"dynn_Can_c_ced__a_tld_o"
 			"dynn_Carcamano"
 			"dynn_Careca"
-			"dynn_Carioca"
-			"dynn_Cariri"
+			"dynn_do_Cariri"
 			"dynn_Carmo_dos_Santos"
 			"dynn_Carquejo"
 			"dynn_Carrasco"
 			"dynn_Carreteiro"
-			"dynn_Carta_Branca"
-			"dynn_Casa_Velha"
-			"dynn_Casca_Grossa"
+			"dynn_Carta-Branca"
+			"dynn_Casavelha"
+			"dynn_Cascagrossa"
 			"dynn_Cavalcanti"
-			"dynn_Cearense"
-			"dynn_Chiquim"
 			"dynn_Cleto"
-			"dynn_Cobra_Preta"
+			"dynn_Cobrapreta"
 			"dynn_Cocada"
-			"dynn_Coco_Verde"
+			"dynn_Coco-Verde"
 			"dynn_Coqueiro"
 			"dynn_Cordeiro"
 			"dynn_Corisco"
 			"dynn_Correia"
 			"dynn_Costa"
-			"dynn_Cravo_Roxo"
-			"dynn_Crian_c_ced_a"
-			"dynn_Dami_a_tld_o"
+			"dynn_Cravo-Roxo"
 			"dynn_Dantas"
 			"dynn_Davi"
 			"dynn_Ded_e_act_"
 			"dynn_Delegado"
-			"dynn_Deus-te-guie"
+			"dynn_Deus-me-Guia"
 			"dynn_Devo_c_ced__a_tld_o"
 			"dynn_Dino"
 			"dynn_Donato"
@@ -111,32 +99,23 @@
 			"dynn_Faz-Tudo"
 			"dynn_Feitosa"
 			"dynn_Ferreira"
-			"dynn_Ferreira_da_Silva"
-			"dynn_Ferreira_de_Souza"
-			"dynn_Ferreira_dos_Santos"
 			"dynn_Ferrugem"
 			"dynn_Fiapo"
-			"dynn_Franc_e_hat_s"
+			"dynn_Fran_c_ced_a"
 			"dynn_Freire"
-			"dynn_Fura_Moita"
+			"dynn_Fura-Moita"
 			"dynn_Furtado"
-			"dynn_Furtado_Quel_e_act_"
 			"dynn_Gabiroba"
 			"dynn_Gadelha"
 			"dynn_Galego"
 			"dynn_Gamb_a_act_"
 			"dynn_Gato"
-			"dynn_Gaucho"
 			"dynn_Gavi_a_tld_o"
 			"dynn_Gitirana"
 			"dynn_God_e_hat_"
 			"dynn_Goiabeira"
-			"dynn_Goiano"
 			"dynn_Gomes"
-			"dynn_Gomes_da_Silva"
-			"dynn_Gomes_de_S_a_act_"
 			"dynn_Granja"
-			"dynn_Gringo"
 			"dynn_Grisalho"
 			"dynn_Gua_c_ced_u"
 			"dynn_Guedes"
@@ -150,10 +129,8 @@
 			"dynn_Jandaia"
 			"dynn_Japa"
 			"dynn_Jararaca"
-			"dynn_Jeca"
 			"dynn_Jerimum"
 			"dynn_Jib_o_act_ia"
-			"dynn_Jiboi_a_tld_o"
 			"dynn_Jitirana"
 			"dynn_Juriti"
 			"dynn_Labareda"
@@ -165,80 +142,56 @@
 			"dynn_Letrado"
 			"dynn_Liberato"
 			"dynn_Limoeiro"
-			"dynn_Lopes_de_S_a_act_"
 			"dynn_Louro"
-			"dynn_Lua_Branca"
+			"dynn_Lua-Branca"
 			"dynn_M_a_tld_o-de-Grelha"
 			"dynn_M_a_tld_o_Foveira"
 			"dynn_Ma_c_ced_arico"
 			"dynn_Mal_i_act_cia"
-			"dynn_Malandro"
-			"dynn_Mamoneira"
-			"dynn_Man_e_act_"
-			"dynn_Manac_a_act_"
+			"dynn_Mamoeira"
 			"dynn_Mandioca"
 			"dynn_Mangabeira"
-			"dynn_Mangua_c_ced_a"
 			"dynn_Mangueira"
 			"dynn_Mansid_a_tld_o"
 			"dynn_Maracuj_a_act_"
 			"dynn_Mariano"
-			"dynn_Marinheiro"
 			"dynn_Marinho"
 			"dynn_Marques"
-			"dynn_Marreca"
+			"dynn_Marreco"
 			"dynn_Martins"
 			"dynn_Mec_a_hat_nico"
-			"dynn_Meia_Noite"
-			"dynn_Mel-com-terra"
+			"dynn_Meia-Noite"
+			"dynn_Mel-com-Terra"
 			"dynn_Mel_a_tld_o"
 			"dynn_Mergulh_a_tld_o"
-			"dynn_Mineiro"
 			"dynn_Miranda"
 			"dynn_Mirim"
 			"dynn_Moderno"
 			"dynn_Moeda"
-			"dynn_Moita_Braba"
+			"dynn_Moita-Braba"
 			"dynn_Moitinha"
 			"dynn_Monteiro"
 			"dynn_Moreira"
 			"dynn_Moreno"
 			"dynn_Morma_c_ced_o"
 			"dynn_Mour_a_tld_o"
-			"dynn_Mulato"
-			"dynn_N_o_act_brega"
 			"dynn_Naro"
 			"dynn_Navieiro"
-			"dynn_Nec_a_tld_o"
-			"dynn_Neg_a_tld_o"
-			"dynn_Nen_e_act_m"
 			"dynn_Nogueira"
-			"dynn_Nordestino"
 			"dynn_Nunes"
-			"dynn_Nunes_de_Souza"
-			"dynn_Padre"
 			"dynn_Paje_u_act_"
 			"dynn_Pancada"
-			"dynn_Paraense"
-			"dynn_Paraguaio"
-			"dynn_Paraibano"
 			"dynn_Passarinho"
-			"dynn_Pauferro"
-			"dynn_Paulista"
+			"dynn_Pau-dos-Ferros"
 			"dynn_Pedreiro"
 			"dynn_Peixe"
 			"dynn_Penteado"
 			"dynn_Pequeno"
 			"dynn_Pequi"
 			"dynn_Pereira"
-			"dynn_Pereira_da_Silva"
-			"dynn_Pereira_e_Silva"
 			"dynn_Periquito"
-			"dynn_Pernambucano"
 			"dynn_Pescador"
-			"dynn_Pinga_Fogo"
-			"dynn_Pingu_c_ced_o"
-			"dynn_Pinheiro"
+			"dynn_Pinga"
 			"dynn_Pintadinho"
 			"dynn_Pintado"
 			"dynn_Pitanga"
@@ -249,12 +202,9 @@
 			"dynn_Porcino"
 			"dynn_Porto"
 			"dynn_Portugu_e_hat_s"
-			"dynn_Potiguara"
 			"dynn_Pra_c_ced_a"
 			"dynn_Prata"
-			"dynn_Preto"
 			"dynn_Professor"
-			"dynn_Profeta_dos_Santos"
 			"dynn_Quatro-Olhos"
 			"dynn_Quel_e_act_"
 			"dynn_Quero-Quero"
@@ -263,8 +213,8 @@
 			"dynn_Reboli_c_ced_o"
 			"dynn_Rel_a_hat_mpago"
 			"dynn_Ribeiro"
-			"dynn_Rio_Branco"
-			"dynn_Rio_Preto"
+			"dynn_Rio-Branco"
+			"dynn_Rio-Preto"
 			"dynn_Rodrigues"
 			"dynn_Roque"
 			"dynn_Rosa"
@@ -277,15 +227,14 @@
 			"dynn_Saracura"
 			"dynn_Sardento"
 			"dynn_Sereno"
-			"dynn_Serra_Branca"
-			"dynn_Sertanejo"
+			"dynn_Serra-Branca"
 			"dynn_Silvino"
 			"dynn_Soares"
 			"dynn_Suspeita"
 			"dynn_Tabaqueiro"
 			"dynn_Tatu"
 			"dynn_Tempestade"
-			"dynn_Tempo_Duro"
+			"dynn_Tempo-Duro"
 			"dynn_Terto"
 			"dynn_Til_a_act_pia"
 			"dynn_Toalha"
@@ -300,22 +249,18 @@
 			"dynn_Ventura"
 			"dynn_Vereda"
 			"dynn_Vesgo"
-			"dynn_Vinte_Cinco"
-			"dynn_Vinte_Dois"
+			"dynn_Vinte-Cinco"
+			"dynn_Vinte-Dois"
 			"dynn_Violeiro"
-			"dynn_Vit_o_act_ria"
-			"dynn_Volta_Seca"
-			"dynn_da_Anta"
+			"dynn_Vitorioso"
+			"dynn_Volta-Seca"
 			"dynn_da_Banda"
 			"dynn_da_Barra"
 			"dynn_da_Cachoeira"
-			"dynn_da_Capital"
-			"dynn_da_Constru_c_ced__a_tld_o"
 			"dynn_da_Cruz"
 			"dynn_da_Farra"
 			"dynn_da_Feira"
 			"dynn_da_Gandaia"
-			"dynn_da_Igreja"
 			"dynn_da_Lua"
 			"dynn_da_Luz"
 			"dynn_da_Mata"
@@ -324,18 +269,15 @@
 			"dynn_da_On_c_ced_a"
 			"dynn_da_Paix_a_tld_o"
 			"dynn_da_Praia"
-			"dynn_da_Quebrada"
-			"dynn_da_Quenga"
 			"dynn_da_Ressaca"
 			"dynn_da_Serra"
 			"dynn_da_Silva"
 			"dynn_da_Umburana"
-			"dynn_das_Piranhas"
+			"dynn_de_Piranhas"
 			"dynn_de_Alencar"
 			"dynn_de_Arruda"
 			"dynn_de_Carvalho"
 			"dynn_de_Engr_a_act_cia"
-			"dynn_de_Engracia"
 			"dynn_de_Farias"
 			"dynn_de_G_o_act_is"
 			"dynn_de_Genoveva"
@@ -371,10 +313,8 @@
 			"dynn_do_Mangue"
 			"dynn_do_Matadouro"
 			"dynn_do_Mate"
-			"dynn_do_Mato_Grosso"
 			"dynn_do_Morro"
 			"dynn_do_Rio"
-			"dynn_do_Sert_a_tld_o"
 			"dynn_do_Telhado"
 			"dynn_do_Tri_a_hat_ngulo"
 			"dynn_do_Vale"
@@ -397,9 +337,9 @@
 			"dynn_Fogo"
 			"dynn_Telhada"
 			"dynn_Armado"
-			"dynn_Senhor_de_Cavalos"
+			"dynn_Senhor-de-Cavalos"
 			"dynn_Jumento"
-			"dynn_Ramos_Verdes"
+			"dynn_Ramos-Verdes"
 			"dynn_Vermelho"
 			"dynn_Amarelo"
 			"dynn_C_e_act_sar"
@@ -409,52 +349,48 @@
 			"dynn_Carrapato"
 			"dynn_Carrapixo"
 			"dynn_Espinho"
+			"dynn_Tripa-Seca"
 		}
 		dynasty_names = {
 			"dynn_A_c_ced_ucena"
 			"dynn_Acerola"
-			"dynn_Alem_a_tld_o"
-			"dynn_Alves"
-			"dynn_Amante"
-			"dynn_Amea_c_ced_o"
+			"dynn_Amado"
+			"dynn_Andiroba"
 			"dynn_Andorinha"
 			"dynn_Ariranha"
-			"dynn_Arvoredo"
+			"dynn_Arvor_e_hat_do"
 			"dynn_Asa_Branca"
 			"dynn_Atividade"
 			"dynn_Bacalhau"
 			"dynn_Baga_c_ced_o"
-			"dynn_Baiano"
 			"dynn_Bal_a_tld_o"
 			"dynn_Baliza"
 			"dynn_Bananeira"
-			"dynn_Barbosa"
+			"dynn_Babosa"
 			"dynn_Barra_Nova"
 			"dynn_Barreiro"
-			"dynn_Batista"
 			"dynn_Beija-Flor"
 			"dynn_Bem-Te-Vi"
-			"dynn_Benevides"
-			"dynn_Bicheiro"
-			"dynn_Bimb_a_tld_o"
-			"dynn_Bizarria"
-			"dynn_Boa_Vista"
-			"dynn_Boca_Negra"
-			"dynn_Boiadeiro"
+			"dynn_Bicudo"
+			"dynn_Bigodinho"
+			"dynn_Vista-Boa"
+			"dynn_Bocanegra"
 			"dynn_Borboleta"
 			"dynn_Br_a_act_s"
 			"dynn_Branco"
 			"dynn_Bravo"
 			"dynn_Brilhante"
-			"dynn_Brito"
+			"dynn_Brita"
 			"dynn_Bronzeado"
+			"dynn_Carna_u_act_ba"
 			"dynn_C_o_hat_co"
+			"dynn_Coqueiros"
 			"dynn_Cabeleira"
 			"dynn_Cabo_Preto"
 			"dynn_Cacheado"
+			"dynn_Carcar_a_act_"
 			"dynn_Cachimbo"
 			"dynn_Caf_e_act_"
-			"dynn_Cafezal"
 			"dynn_Cai_c_ced_ara"
 			"dynn_Caipira"
 			"dynn_Caix_a_tld_o"
@@ -464,41 +400,34 @@
 			"dynn_Cambuci"
 			"dynn_Canabrava"
 			"dynn_Canavieira"
-			"dynn_Candango"
 			"dynn_Canhoto"
-			"dynn_Cansan_c_ced__a_tld_o"
-			"dynn_Capixaba"
+			"dynn_Can_c_ced__a_tld_o"
 			"dynn_Carcamano"
 			"dynn_Careca"
-			"dynn_Carioca"
-			"dynn_Cariri"
+			"dynn_do_Cariri"
 			"dynn_Carmo_dos_Santos"
 			"dynn_Carquejo"
 			"dynn_Carrasco"
 			"dynn_Carreteiro"
-			"dynn_Carta_Branca"
-			"dynn_Casa_Velha"
-			"dynn_Casca_Grossa"
+			"dynn_Carta-Branca"
+			"dynn_Casavelha"
+			"dynn_Cascagrossa"
 			"dynn_Cavalcanti"
-			"dynn_Cearense"
-			"dynn_Chiquim"
 			"dynn_Cleto"
-			"dynn_Cobra_Preta"
+			"dynn_Cobrapreta"
 			"dynn_Cocada"
-			"dynn_Coco_Verde"
+			"dynn_Coco-Verde"
 			"dynn_Coqueiro"
 			"dynn_Cordeiro"
 			"dynn_Corisco"
 			"dynn_Correia"
 			"dynn_Costa"
-			"dynn_Cravo_Roxo"
-			"dynn_Crian_c_ced_a"
-			"dynn_Dami_a_tld_o"
+			"dynn_Cravo-Roxo"
 			"dynn_Dantas"
 			"dynn_Davi"
 			"dynn_Ded_e_act_"
 			"dynn_Delegado"
-			"dynn_Deus-te-guie"
+			"dynn_Deus-me-Guia"
 			"dynn_Devo_c_ced__a_tld_o"
 			"dynn_Dino"
 			"dynn_Donato"
@@ -508,32 +437,23 @@
 			"dynn_Faz-Tudo"
 			"dynn_Feitosa"
 			"dynn_Ferreira"
-			"dynn_Ferreira_da_Silva"
-			"dynn_Ferreira_de_Souza"
-			"dynn_Ferreira_dos_Santos"
 			"dynn_Ferrugem"
 			"dynn_Fiapo"
-			"dynn_Franc_e_hat_s"
+			"dynn_Fran_c_ced_a"
 			"dynn_Freire"
-			"dynn_Fura_Moita"
+			"dynn_Fura-Moita"
 			"dynn_Furtado"
-			"dynn_Furtado_Quel_e_act_"
 			"dynn_Gabiroba"
 			"dynn_Gadelha"
 			"dynn_Galego"
 			"dynn_Gamb_a_act_"
 			"dynn_Gato"
-			"dynn_Gaucho"
 			"dynn_Gavi_a_tld_o"
 			"dynn_Gitirana"
 			"dynn_God_e_hat_"
 			"dynn_Goiabeira"
-			"dynn_Goiano"
 			"dynn_Gomes"
-			"dynn_Gomes_da_Silva"
-			"dynn_Gomes_de_S_a_act_"
 			"dynn_Granja"
-			"dynn_Gringo"
 			"dynn_Grisalho"
 			"dynn_Gua_c_ced_u"
 			"dynn_Guedes"
@@ -547,10 +467,8 @@
 			"dynn_Jandaia"
 			"dynn_Japa"
 			"dynn_Jararaca"
-			"dynn_Jeca"
 			"dynn_Jerimum"
 			"dynn_Jib_o_act_ia"
-			"dynn_Jiboi_a_tld_o"
 			"dynn_Jitirana"
 			"dynn_Juriti"
 			"dynn_Labareda"
@@ -562,80 +480,56 @@
 			"dynn_Letrado"
 			"dynn_Liberato"
 			"dynn_Limoeiro"
-			"dynn_Lopes_de_S_a_act_"
 			"dynn_Louro"
-			"dynn_Lua_Branca"
+			"dynn_Lua-Branca"
 			"dynn_M_a_tld_o-de-Grelha"
 			"dynn_M_a_tld_o_Foveira"
 			"dynn_Ma_c_ced_arico"
 			"dynn_Mal_i_act_cia"
-			"dynn_Malandro"
-			"dynn_Mamoneira"
-			"dynn_Man_e_act_"
-			"dynn_Manac_a_act_"
+			"dynn_Mamoeira"
 			"dynn_Mandioca"
 			"dynn_Mangabeira"
-			"dynn_Mangua_c_ced_a"
 			"dynn_Mangueira"
 			"dynn_Mansid_a_tld_o"
 			"dynn_Maracuj_a_act_"
 			"dynn_Mariano"
-			"dynn_Marinheiro"
 			"dynn_Marinho"
 			"dynn_Marques"
-			"dynn_Marreca"
+			"dynn_Marreco"
 			"dynn_Martins"
 			"dynn_Mec_a_hat_nico"
-			"dynn_Meia_Noite"
-			"dynn_Mel-com-terra"
+			"dynn_Meia-Noite"
+			"dynn_Mel-com-Terra"
 			"dynn_Mel_a_tld_o"
 			"dynn_Mergulh_a_tld_o"
-			"dynn_Mineiro"
 			"dynn_Miranda"
 			"dynn_Mirim"
 			"dynn_Moderno"
 			"dynn_Moeda"
-			"dynn_Moita_Braba"
+			"dynn_Moita-Braba"
 			"dynn_Moitinha"
 			"dynn_Monteiro"
 			"dynn_Moreira"
 			"dynn_Moreno"
 			"dynn_Morma_c_ced_o"
 			"dynn_Mour_a_tld_o"
-			"dynn_Mulato"
-			"dynn_N_o_act_brega"
 			"dynn_Naro"
 			"dynn_Navieiro"
-			"dynn_Nec_a_tld_o"
-			"dynn_Neg_a_tld_o"
-			"dynn_Nen_e_act_m"
 			"dynn_Nogueira"
-			"dynn_Nordestino"
 			"dynn_Nunes"
-			"dynn_Nunes_de_Souza"
-			"dynn_Padre"
 			"dynn_Paje_u_act_"
 			"dynn_Pancada"
-			"dynn_Paraense"
-			"dynn_Paraguaio"
-			"dynn_Paraibano"
 			"dynn_Passarinho"
-			"dynn_Pauferro"
-			"dynn_Paulista"
+			"dynn_Pau-dos-Ferros"
 			"dynn_Pedreiro"
 			"dynn_Peixe"
 			"dynn_Penteado"
 			"dynn_Pequeno"
 			"dynn_Pequi"
 			"dynn_Pereira"
-			"dynn_Pereira_da_Silva"
-			"dynn_Pereira_e_Silva"
 			"dynn_Periquito"
-			"dynn_Pernambucano"
 			"dynn_Pescador"
-			"dynn_Pinga_Fogo"
-			"dynn_Pingu_c_ced_o"
-			"dynn_Pinheiro"
+			"dynn_Pinga"
 			"dynn_Pintadinho"
 			"dynn_Pintado"
 			"dynn_Pitanga"
@@ -646,12 +540,9 @@
 			"dynn_Porcino"
 			"dynn_Porto"
 			"dynn_Portugu_e_hat_s"
-			"dynn_Potiguara"
 			"dynn_Pra_c_ced_a"
 			"dynn_Prata"
-			"dynn_Preto"
 			"dynn_Professor"
-			"dynn_Profeta_dos_Santos"
 			"dynn_Quatro-Olhos"
 			"dynn_Quel_e_act_"
 			"dynn_Quero-Quero"
@@ -660,8 +551,8 @@
 			"dynn_Reboli_c_ced_o"
 			"dynn_Rel_a_hat_mpago"
 			"dynn_Ribeiro"
-			"dynn_Rio_Branco"
-			"dynn_Rio_Preto"
+			"dynn_Rio-Branco"
+			"dynn_Rio-Preto"
 			"dynn_Rodrigues"
 			"dynn_Roque"
 			"dynn_Rosa"
@@ -674,15 +565,14 @@
 			"dynn_Saracura"
 			"dynn_Sardento"
 			"dynn_Sereno"
-			"dynn_Serra_Branca"
-			"dynn_Sertanejo"
+			"dynn_Serra-Branca"
 			"dynn_Silvino"
 			"dynn_Soares"
 			"dynn_Suspeita"
 			"dynn_Tabaqueiro"
 			"dynn_Tatu"
 			"dynn_Tempestade"
-			"dynn_Tempo_Duro"
+			"dynn_Tempo-Duro"
 			"dynn_Terto"
 			"dynn_Til_a_act_pia"
 			"dynn_Toalha"
@@ -697,22 +587,18 @@
 			"dynn_Ventura"
 			"dynn_Vereda"
 			"dynn_Vesgo"
-			"dynn_Vinte_Cinco"
-			"dynn_Vinte_Dois"
+			"dynn_Vinte-Cinco"
+			"dynn_Vinte-Dois"
 			"dynn_Violeiro"
-			"dynn_Vit_o_act_ria"
-			"dynn_Volta_Seca"
-			"dynn_da_Anta"
+			"dynn_Vitorioso"
+			"dynn_Volta-Seca"
 			"dynn_da_Banda"
 			"dynn_da_Barra"
 			"dynn_da_Cachoeira"
-			"dynn_da_Capital"
-			"dynn_da_Constru_c_ced__a_tld_o"
 			"dynn_da_Cruz"
 			"dynn_da_Farra"
 			"dynn_da_Feira"
 			"dynn_da_Gandaia"
-			"dynn_da_Igreja"
 			"dynn_da_Lua"
 			"dynn_da_Luz"
 			"dynn_da_Mata"
@@ -721,18 +607,15 @@
 			"dynn_da_On_c_ced_a"
 			"dynn_da_Paix_a_tld_o"
 			"dynn_da_Praia"
-			"dynn_da_Quebrada"
-			"dynn_da_Quenga"
 			"dynn_da_Ressaca"
 			"dynn_da_Serra"
 			"dynn_da_Silva"
 			"dynn_da_Umburana"
-			"dynn_das_Piranhas"
+			"dynn_de_Piranhas"
 			"dynn_de_Alencar"
 			"dynn_de_Arruda"
 			"dynn_de_Carvalho"
 			"dynn_de_Engr_a_act_cia"
-			"dynn_de_Engracia"
 			"dynn_de_Farias"
 			"dynn_de_G_o_act_is"
 			"dynn_de_Genoveva"
@@ -768,10 +651,8 @@
 			"dynn_do_Mangue"
 			"dynn_do_Matadouro"
 			"dynn_do_Mate"
-			"dynn_do_Mato_Grosso"
 			"dynn_do_Morro"
 			"dynn_do_Rio"
-			"dynn_do_Sert_a_tld_o"
 			"dynn_do_Telhado"
 			"dynn_do_Tri_a_hat_ngulo"
 			"dynn_do_Vale"
@@ -794,9 +675,9 @@
 			"dynn_Fogo"
 			"dynn_Telhada"
 			"dynn_Armado"
-			"dynn_Senhor_de_Cavalos"
+			"dynn_Senhor-de-Cavalos"
 			"dynn_Jumento"
-			"dynn_Ramos_Verdes"
+			"dynn_Ramos-Verdes"
 			"dynn_Vermelho"
 			"dynn_Amarelo"
 			"dynn_C_e_act_sar"
@@ -806,6 +687,7 @@
 			"dynn_Carrapato"
 			"dynn_Carrapixo"
 			"dynn_Espinho"
+			"dynn_Tripa-Seca"
 		}
 
 		male_names = {
@@ -841,14 +723,14 @@
 		dynasty_of_location_prefix = "dynnp_de"
 
 		# Chance of male children being named after their paternal or maternal grandfather, or their father. Sum must not exceed 100.
-		pat_grf_name_chance = 10
-		mat_grf_name_chance = 10
-		father_name_chance = 5
+		pat_grf_name_chance = 20
+		mat_grf_name_chance = 20
+		father_name_chance = 40
 
 		# Chance of female children being named after their paternal or maternal grandmother, or their mother. Sum must not exceed 100.
-		pat_grm_name_chance = 10
-		mat_grm_name_chance = 10
-		mother_name_chance = 5
+		pat_grm_name_chance = 40
+		mat_grm_name_chance = 40
+		mother_name_chance = 0
 
 		ethnicities = {
 	5 = african
@@ -1310,13 +1192,13 @@
 			"dynn_do_Sert_a_tld_o"
 			"dynn_do_Vale"
 			"dynn_dos_Ip_e_hat_s"
-}
+		}
 
 		male_names = {
 			Adalberto Alberto Anderson Andr_e_act_ Andre Antonio Armando Augusto Arslan
 			Baldu_i_act_no Ben_i_act_cio Baltazar Ba-Tu
 			Carlos Charles C_i_act_cero Clementino Cl_a_act_udio
-			Daniel Danilo Djalma
+			D_a_act_cio Daniel Danilo
 			Edgar Eduardo Eg_i_act_dio
 			Fabio Felipe Fernando Francisco
 			Gabriel Geraldo Gilson Gonzaga
@@ -1326,8 +1208,8 @@
 			Kaio
 			Lu_i_act_s Lucas Luciano
 			Manoel Manuel Marcelo Marcos Marinaldo Mateus Maur_i_act_cio Maur_i_act_lio
-			Nilson
-			Ossesio Osvaldo
+			Nilson Nivaldo
+			Oss_e_act_sio Osvaldo
 			Paulo Pedro
 			Rafael Raimundo Raul Renildo Ricardo Roberto
 			S_e_act_rgio S_i_act_lvio Salatiel Sebasti_a_tld_o Severino Silvio
@@ -1362,14 +1244,14 @@
 		dynasty_of_location_prefix = "dynnp_de"
 
 		# Chance of male children being named after their paternal or maternal grandfather, or their father. Sum must not exceed 100.
-		pat_grf_name_chance = 10
-		mat_grf_name_chance = 10
-		father_name_chance = 5
+		pat_grf_name_chance = 20
+		mat_grf_name_chance = 20
+		father_name_chance = 20
 
 		# Chance of female children being named after their paternal or maternal grandmother, or their mother. Sum must not exceed 100.
-		pat_grm_name_chance = 10
-		mat_grm_name_chance = 10
-		mother_name_chance = 5
+		pat_grm_name_chance = 20
+		mat_grm_name_chance = 20
+		mother_name_chance = 10
 
 		ethnicities = {
 	15 = african
@@ -1895,7 +1777,6 @@
 			"dynn_do_Vale"
 			"dynn_dos_Ip_e_hat_s"
 		}
-
 		male_names = {
 			A_act_lvaro Abelardo Ad_i_act_lson Adailton Adalberto Adalberto Adalto Adem_a_act_r Adem_i_act_r Adriano Afonso Agenor Aguinaldo Alberto Alcides Alex Alu_i_act_zio Andr_e_act_ Ant_o_hat_nio Algemiro Arist_o_act_fanes Armando Arnaldo Assis Augusto Avenzoar Abr_a_tld_o
 			Benjamin Bento Beto
@@ -1949,13 +1830,13 @@
 		dynasty_of_location_prefix = "dynnp_de"
 
 		# Chance of male children being named after their paternal or maternal grandfather, or their father. Sum must not exceed 100.
-		pat_grf_name_chance = 10
-		mat_grf_name_chance = 10
+		pat_grf_name_chance = 40
+		mat_grf_name_chance = 40
 		father_name_chance = 5
 
 		# Chance of female children being named after their paternal or maternal grandmother, or their mother. Sum must not exceed 100.
-		pat_grm_name_chance = 10
-		mat_grm_name_chance = 10
+		pat_grm_name_chance = 40
+		mat_grm_name_chance = 40
 		mother_name_chance = 5
 
 		ethnicities = {
@@ -2559,13 +2440,13 @@
 		dynasty_of_location_prefix = "dynnp_de"
 
 		# Chance of male children being named after their paternal or maternal grandfather, or their father. Sum must not exceed 100.
-		pat_grf_name_chance = 10
-		mat_grf_name_chance = 10
-		father_name_chance = 5
+		pat_grf_name_chance = 20
+		mat_grf_name_chance = 20
+		father_name_chance = 10
 
 		# Chance of female children being named after their paternal or maternal grandmother, or their mother. Sum must not exceed 100.
-		pat_grm_name_chance = 10
-		mat_grm_name_chance = 10
+		pat_grm_name_chance = 25
+		mat_grm_name_chance = 25
 		mother_name_chance = 5
 
 		ethnicities = {
@@ -3100,14 +2981,14 @@
 		dynasty_of_location_prefix = "dynnp_de"
 
 		# Chance of male children being named after their paternal or maternal grandfather, or their father. Sum must not exceed 100.
-		pat_grf_name_chance = 10
-		mat_grf_name_chance = 10
-		father_name_chance = 5
+		pat_grf_name_chance = 35
+		mat_grf_name_chance = 35
+		father_name_chance = 10
 
 		# Chance of female children being named after their paternal or maternal grandmother, or their mother. Sum must not exceed 100.
-		pat_grm_name_chance = 10
-		mat_grm_name_chance = 10
-		mother_name_chance = 5
+		pat_grm_name_chance = 25
+		mat_grm_name_chance = 25
+		mother_name_chance = 1
 
 		ethnicities = {
 	5 = african
@@ -3911,13 +3792,13 @@
 		dynasty_of_location_prefix = "dynnp_de"
 
 		# Chance of male children being named after their paternal or maternal grandfather, or their father. Sum must not exceed 100.
-		pat_grf_name_chance = 10
-		mat_grf_name_chance = 10
-		father_name_chance = 5
+		pat_grf_name_chance = 15
+		mat_grf_name_chance = 15
+		father_name_chance = 50
 
 		# Chance of female children being named after their paternal or maternal grandmother, or their mother. Sum must not exceed 100.
-		pat_grm_name_chance = 10
-		mat_grm_name_chance = 10
+		pat_grm_name_chance = 25
+		mat_grm_name_chance = 25
 		mother_name_chance = 5
 
 		ethnicities = {
@@ -4447,14 +4328,14 @@
 		dynasty_of_location_prefix = "dynnp_de"
 
 		# Chance of male children being named after their paternal or maternal grandfather, or their father. Sum must not exceed 100.
-		pat_grf_name_chance = 10
-		mat_grf_name_chance = 10
-		father_name_chance = 5
+		pat_grf_name_chance = 33
+		mat_grf_name_chance = 33
+		father_name_chance = 4
 
 		# Chance of female children being named after their paternal or maternal grandmother, or their mother. Sum must not exceed 100.
-		pat_grm_name_chance = 10
-		mat_grm_name_chance = 10
-		mother_name_chance = 5
+		pat_grm_name_chance = 25
+		mat_grm_name_chance = 25
+		mother_name_chance = 2
 
 		ethnicities = {
 	5 = african
@@ -4987,14 +4868,14 @@
 		dynasty_of_location_prefix = "dynnp_de"
 
 		# Chance of male children being named after their paternal or maternal grandfather, or their father. Sum must not exceed 100.
-		pat_grf_name_chance = 10
-		mat_grf_name_chance = 10
-		father_name_chance = 5
+		pat_grf_name_chance = 15
+		mat_grf_name_chance = 15
+		father_name_chance = 20
 
 		# Chance of female children being named after their paternal or maternal grandmother, or their mother. Sum must not exceed 100.
-		pat_grm_name_chance = 10
-		mat_grm_name_chance = 10
-		mother_name_chance = 5
+		pat_grm_name_chance = 15
+		mat_grm_name_chance = 15
+		mother_name_chance = 20
 
 		ethnicities = {
 	5 = african
@@ -6323,14 +6204,14 @@
 		dynasty_of_location_prefix = "dynnp_de"
 
 		# Chance of male children being named after their paternal or maternal grandfather, or their father. Sum must not exceed 100.
-		pat_grf_name_chance = 10
-		mat_grf_name_chance = 10
-		father_name_chance = 5
+		pat_grf_name_chance = 33
+		mat_grf_name_chance = 33
+		father_name_chance = 33
 
 		# Chance of female children being named after their paternal or maternal grandmother, or their mother. Sum must not exceed 100.
-		pat_grm_name_chance = 10
-		mat_grm_name_chance = 10
-		mother_name_chance = 5
+		pat_grm_name_chance = 25
+		mat_grm_name_chance = 25
+		mother_name_chance = 1
 
 		ethnicities = {
 	15 = african


### PR DESCRIPTION
- Rechecked Sertanistas for dynasty names that might be considered offensive, removing the ones that could be interpreted as such.
- Removed dynasty names that would caractherize individuals not from the region (ex: dynn_Goiano). This can be achieved in other means in the game without the usage of said wording.
- Added different naming chance for children based on parent and grandparents to a higher degree due to the cultural practice in the region of naming children after parents and grandparents. Might affect children having the same name often, needing to be tested and balanced.