### PR TITLE
Fix to missing quotation

### DIFF
--- a/actual game files/ate-ck3/common/culture/cultures/000_nordestino.txt
+++ b/actual game files/ate-ck3/common/culture/cultures/000_nordestino.txt
@@ -1687,7 +1687,7 @@
 			"dynn_Mipibu"
 			"dynn_Zuza"
 			"dynn_Guilhem"
-			"dynn_Carrilho
+			"dynn_Carrilho"
 			"dynn_Medeiros"
 		}
 		dynasty_names = {


### PR DESCRIPTION
Nordestino Culture had a missing quotation in a dynasty name, causing a bug.